### PR TITLE
Add event IDs for webhooks to filter out un-needed messages.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -87,7 +87,7 @@ describe('bbb-webhooks tests', () => {
 
   describe('GET /hooks/destroy', () => {
     before( (done) => {
-      Hook.addSubscription(Helpers.callback,null,false,() => { done(); });
+      Hook.addSubscription(Helpers.callback,null,null,false,() => { done(); });
     });
     it('should destroy a hook', (done) => {
       const hooks = Hook.allGlobalSync();
@@ -152,7 +152,7 @@ describe('bbb-webhooks tests', () => {
   describe('Hook queues', () => {
     before( () => {
       Application.redisPubSubClient().psubscribe("test-channel");
-      Hook.addSubscription(Helpers.callback,null,false, (err,reply) => {
+      Hook.addSubscription(Helpers.callback,null,null,false, (err,reply) => {
         const hooks = Hook.allGlobalSync();
         const hook = hooks[0];
         const hook2 = hooks[hooks.length -1];
@@ -243,7 +243,7 @@ describe('bbb-webhooks tests', () => {
   describe('/POST raw message', () => {
     before( () => {
       Application.redisPubSubClient().psubscribe("test-channel");
-      Hook.addSubscription(Helpers.callback,null,true, (err,hook) => {
+      Hook.addSubscription(Helpers.callback,null,null,true, (err,hook) => {
         Helpers.flushredis(hook);
       })
     });

--- a/web_server.js
+++ b/web_server.js
@@ -50,6 +50,7 @@ module.exports = class WebServer {
     const urlObj = url.parse(req.url, true);
     const callbackURL = urlObj.query["callbackURL"];
     const meetingID = urlObj.query["meetingID"];
+    const eventID = urlObj.query["eventID"];
     let getRaw = urlObj.query["getRaw"];
     if (getRaw){
       getRaw = JSON.parse(getRaw.toLowerCase());
@@ -60,7 +61,7 @@ module.exports = class WebServer {
     if (callbackURL == null) {
       respondWithXML(res, responses.missingParamCallbackURL);
     } else {
-      Hook.addSubscription(callbackURL, meetingID, getRaw, function(error, hook) {
+      Hook.addSubscription(callbackURL, meetingID, eventID, getRaw, function(error, hook) {
         let msg;
         if (error != null) { // the only error for now is for duplicated callbackURL
           msg = responses.createDuplicated(hook.id);
@@ -76,7 +77,7 @@ module.exports = class WebServer {
   // Create a permanent hook. Permanent hooks can't be deleted via API and will try to emit a message until it succeed
   createPermanents(callback) {
     for (let i = 0; i < config.get("hooks.permanentURLs").length; i++) {
-      Hook.addSubscription(config.get("hooks.permanentURLs")[i].url, null, config.get("hooks.permanentURLs")[i].getRaw, function(error, hook) {
+      Hook.addSubscription(config.get("hooks.permanentURLs")[i].url, null, null, config.get("hooks.permanentURLs")[i].getRaw, function(error, hook) {
         if (error != null) { // there probably won't be any errors here
           Logger.info("[WebServer] duplicated permanent hook", error);
         } else if (hook != null) {
@@ -131,6 +132,7 @@ module.exports = class WebServer {
       msg +=   `<hookID>${hook.id}</hookID>`;
       msg +=   `<callbackURL><![CDATA[${hook.callbackURL}]]></callbackURL>`;
       if (!hook.isGlobal()) { msg +=   `<meetingID><![CDATA[${hook.externalMeetingID}]]></meetingID>`; }
+      if (hook.eventID != null) { msg +=   `<eventID>${hook.eventID.join()}</eventID>`; }
       msg +=   `<permanentHook>${hook.permanent}</permanentHook>`;
       msg +=   `<rawData>${hook.getRaw}</rawData>`;
       msg += "</hook>";


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Adds the ability to filter out un-needed messages in web hooks.
<!-- A brief description of each change being made with this pull request. -->

### Motivation

Web hooks send a lot of data and messages, while not all messages are needed. After this change, when registering a hook, it is optional to add an eventID parameter with comma-separated event IDs, so only those will be sent.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Needs to update bbb-webhooks doc (currently they are not updated to the current situation).
