### PR TITLE
add group chat, pad, presentation events

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -17,6 +17,8 @@ hooks:
     - from-akka-apps-redis-channel
     - from-bbb-web-redis-channel
     - from-akka-apps-chat-redis-channel
+    - from-akka-apps-pres-redis-channel
+    - from-etherpad-redis-channel
     - bigbluebutton:from-bbb-apps:meeting
     - bigbluebutton:from-bbb-apps:users
     - bigbluebutton:from-bbb-apps:chat


### PR DESCRIPTION
This pull request was previously submitted as https://github.com/bigbluebutton/bigbluebutton/pull/8895, before bbb-webhooks was moved to its own repository. @antobinary requested @pedrobmarin to transfer it here, but I can of course do that too.

- The public chat produces `GroupChatMessageBroadcastEvtMsg` events which were not listened for and have a slightly different mapping than the existing chat events. They can be distinguished from private chat messages by the `MAIN-PUBLIC-GROUP-CHAT` chat ID.
- Shared notes produce `PadUpdateSysMsg` events, which were neither listened for nor mapped.
- Presentation uploads produce `SetCurrentPresentationEvtMsg` events, which were not mapped.