### PR TITLE
Update Dockerfile to Node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:18-slim
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Tested a default configuration for my 2.5 and 2.6 servers and all hooks tried where delivered successfully.