### PR TITLE
(xAPI) - ensure the correct lrs_endpoint is used

### DIFF
--- a/src/out/xapi/xapi.js
+++ b/src/out/xapi/xapi.js
@@ -62,7 +62,9 @@ export default class XAPI {
       headers,
     };
 
-    const xAPIEndpoint = new URL("xAPI/statements", lrs_endpoint);
+    // Remove /xapi(/)(statements)(/) from the end of the lrs_endpoint to ensure the correct endpoint is used
+    const fixed_lrs_endpoint = lrs_endpoint.replace(/\/xapi\/?(statements)?\/?$/i, '');
+    const xAPIEndpoint = new URL("xAPI/statements", fixed_lrs_endpoint);
 
     try {
       const response = await fetch(xAPIEndpoint, requestOptions);


### PR DESCRIPTION
- Added a simple fix that ensures the correct lrs_endpoint is used.
E.g.: If the lrs_endpoint is set as "https://url.com/xAPI/", the module doesn't try to make it  "https://url.com/xAPI/xAPI/statements" which would render the endpoint incorrect.