### PR TITLE
xAPI: add support for meta_xapi-create-end-actor-name

### DIFF
--- a/src/out/xapi/README.md
+++ b/src/out/xapi/README.md
@@ -57,6 +57,11 @@ You have the option to set relevant metadata when creating a meeting in Big Blue
 
 If you set `meta_xapi-enabled` to false, no xAPI events will be generated or sent to the LRS for that particular meeting. This provides the flexibility to choose which meetings should be tracked using xAPI.
 
+### meta_xapi-create-end-actor-name
+- **Description**: This parameter specifies the actor name to be used in the meeting-created/ended (Initialized/Terminated) statements
+- **Value Format**: string
+- **Default Value**: `<unknown>`
+
 ### meta_secret-lrs-payload
 - **Description**: This parameter allows you to specify the credentials and endpoint of the Learning Record Store (LRS) where the xAPI events will be sent. The payload is a Base64-encoded string representing a JSON object encrypted (AES 256/PBKDF2) using the **server secret** as the **passphrase**.
 - **Value Format**: Base64-encoded JSON object encrypted with AES 256/PBKDF2 encryption

--- a/src/out/xapi/compartment.js
+++ b/src/out/xapi/compartment.js
@@ -7,7 +7,8 @@ export class meetingCompartment extends StorageCompartmentKV {
 
   async addOrUpdateMeetingData(meeting_data) {
     const { internal_meeting_id, context_registration, planned_duration,
-      create_time, meeting_name, xapi_enabled, lrs_endpoint, lrs_token } = meeting_data;
+      create_time, meeting_name, xapi_enabled, create_end_actor_name,
+      lrs_endpoint, lrs_token } = meeting_data;
 
     const payload = {
       internal_meeting_id,
@@ -16,6 +17,7 @@ export class meetingCompartment extends StorageCompartmentKV {
       create_time,
       meeting_name,
       xapi_enabled,
+      create_end_actor_name,
       lrs_endpoint,
       lrs_token,
     };

--- a/src/out/xapi/templates.js
+++ b/src/out/xapi/templates.js
@@ -14,7 +14,8 @@ export default function getXAPIStatement(event, meeting_data, user_data = null, 
     context_registration,
     session_id,
     planned_duration,
-    create_time } = meeting_data;
+    create_time,
+    create_end_actor_name } = meeting_data;
 
   const planned_duration_ISO = Duration.fromObject({ minutes: planned_duration }).toISO();
   const create_time_ISO = DateTime.fromMillis(create_time).toUTC().toISO();
@@ -106,12 +107,14 @@ export default function getXAPIStatement(event, meeting_data, user_data = null, 
 
     // Custom 'meeting-created' attributes
     if (eventId == 'meeting-created') {
+      statement.actor.account.name = create_end_actor_name;
       statement.context.extensions["http://id.tincanapi.com/extension/planned-duration"] = planned_duration_ISO
       statement.timestamp = create_time_ISO;
     }
 
     // Custom 'meeting-ended' attributes
     else if (eventId == 'meeting-ended') {
+      statement.actor.account.name = create_end_actor_name;
       statement.context.extensions["http://id.tincanapi.com/extension/planned-duration"] = planned_duration_ISO
       statement.result = {
         "duration": Duration.fromMillis(eventTs - create_time).toISO()

--- a/src/out/xapi/xapi.js
+++ b/src/out/xapi/xapi.js
@@ -102,6 +102,7 @@ export default class XAPI {
         meeting_data.create_time = event.data.attributes.meeting["create-time"];
         meeting_data.meeting_name = event.data.attributes.meeting.name;
         meeting_data.xapi_enabled = event.data.attributes.meeting.metadata?.["xapi-enabled"] !== 'false' ? 'true' : 'false';
+        meeting_data.create_end_actor_name = event.data.attributes.meeting.metadata?.["xapi-create-end-actor-name"] || "<unknown>";
 
         const lrs_payload = event.data.attributes.meeting.metadata?.["secret-lrs-payload"];
         let lrs_endpoint = '';


### PR DESCRIPTION
Add support for specifying the actor to be used in the create/end statements in the xAPI module, via the `meta_xapi-create-end-actor-name` metaparameter.
If the metaparam is undefined, the default value is `<unknown>` (current behavior).