### PR TITLE
chore: update github-slug-action to latest version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 
-      - uses: rlespinasse/github-slug-action@v4
+      - uses: rlespinasse/github-slug-action@v4.4.1
 
       - name: Calculate tag
         id: tag


### PR DESCRIPTION
Doing so in order to dismiss a vulnerability warning from dependabot.