### PR TITLE
fix: re-enable test and hadolint workflows

### DIFF
--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -2,6 +2,13 @@ name: Run hadolint
 on:
   workflow_dispatch:
   workflow_call:
+  push:
+    branches:
+      - develop
+      - main
+    tags:
+      - '*'
+  pull_request:
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -2,6 +2,13 @@ name: Run tests
 on:
   workflow_dispatch:
   workflow_call:
+  push:
+    branches:
+      - develop
+      - main
+    tags:
+      - '*'
+  pull_request:
 permissions:
   contents: read
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+### UNRELEASED
+
+* fix: re-enable test and hadolint workflows
+
 ### v3.6.0
 
 * feat: add docker matrix build to support arm64


### PR DESCRIPTION
Restore workflows inadvertently disabled in https://github.com/bigbluebutton/bbb-webhooks/pull/70.